### PR TITLE
Add privacy API support (for GDPR) to make plugin Moodle 3.5 compliant

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,78 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for theme_ncmboost.
+ *
+ * @package    theme_ncmboost
+ * @copyright  2018 Andrew Nicols <andrew@nicols.co.uk>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace theme_ncmboost\privacy;
+
+use \core_privacy\local\metadata\collection;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * The boost theme stores a user preference data.
+ *
+ * @copyright  2018 Andrew Nicols <andrew@nicols.co.uk>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements
+    // This plugin has data.
+    \core_privacy\local\metadata\provider,
+    // This plugin has some sitewide user preferences to export.
+    \core_privacy\local\request\user_preference_provider {
+
+    /** The user preference for the navigation drawer. */
+    const DRAWER_OPEN_NAV = 'drawer-open-nav';
+
+    /**
+     * Returns meta data about this system.
+     *
+     * @param  collection $items The initialised item collection to add items to.
+     * @return collection A listing of user data stored through this system.
+     */
+    public static function get_metadata(collection $items) : collection {
+        $items->add_user_preference(self::DRAWER_OPEN_NAV, 'privacy:metadata:preference:draweropennav');
+        return $items;
+    }
+
+    /**
+     * Store all user preferences for the plugin.
+     *
+     * @param int $userid The userid of the user whose data is to be exported.
+     */
+    public static function export_user_preferences(int $userid) {
+        $draweropennavpref = get_user_preferences(self::DRAWER_OPEN_NAV, null, $userid);
+
+        if (isset($draweropennavpref)) {
+            $preferencestring = get_string('privacy:drawernavclosed', 'theme_ncmboost');
+            if ($draweropennavpref == 'true') {
+                $preferencestring = get_string('privacy:drawernavopen', 'theme_ncmboost');
+            }
+            \core_privacy\local\request\writer::export_user_preference(
+                'theme_ncmboost',
+                self::DRAWER_OPEN_NAV,
+                $draweropennavpref,
+                $preferencestring
+            );
+        }
+    }
+}

--- a/lang/en/theme_ncmboost.php
+++ b/lang/en/theme_ncmboost.php
@@ -114,4 +114,6 @@ $string['manualaccounttitle'] = 'Manual Accounts Only';
 // ....Button Primary.
 $string['ncmbtnprimarycolor'] = 'Button Primary Colour';
 $string['ncmbtnprimarycolor_desc'] = 'The button primary colour.';
-
+$string['privacy:metadata:preference:draweropennav'] = 'The user\'s preference for hiding or showing the drawer menu navigation.';
+$string['privacy:drawernavclosed'] = 'The current preference for the navigation drawer is closed.';
+$string['privacy:drawernavopen'] = 'The current preference for the navigation drawer is open.';

--- a/version.php
+++ b/version.php
@@ -26,10 +26,10 @@
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2018080700;
+$plugin->version = 2018080900;
 
 // This is the version of Moodle this plugin requires.
-$plugin->requires = 2016112900.00;
+$plugin->requires = 2018050800;
 
 // This is the component name of the plugin - it always starts with 'theme_'
 // for themes and should be the same as the name of the folder.
@@ -37,7 +37,7 @@ $plugin->component = 'theme_ncmboost';
 
 // This is a list of plugins, this plugin depends on (and their versions).
 $plugin->dependencies = [
-    'theme_boost' => 2016102100
+        'theme_boost' => 2018051400
 ];
 
 // This is a stable release.


### PR DESCRIPTION
Updating the plugin for Moodle 3.5. 
This will make the theme incompatible with earlier versions of Moodle. It may be worth adding this as a separate branch.