### PR TITLE
WR#367478 Fix message drawer and icon

### DIFF
--- a/templates/columns2.mustache
+++ b/templates/columns2.mustache
@@ -90,6 +90,7 @@
             </div>
         </div>
     </div>
+    {{{ output.standard_after_main_region_html }}}
     {{> theme_ncmboost/footer }}
 </div>
 </body>


### PR DESCRIPTION
Fix the message icon, which was not doing anything when clicking on it
![message_drawer](https://user-images.githubusercontent.com/81541815/137427185-7ac73c4a-ba52-4f4c-a547-7236e9988f78.png)
.
